### PR TITLE
Workaround fix for bug #141

### DIFF
--- a/tests/test12.html
+++ b/tests/test12.html
@@ -26,14 +26,15 @@
 <h1>Able Player Test #12:<br/>Video player with <em>default</em> closed captions</h1>
 
 <p>This test page was designed for testing a bug in which certain browsers display captions even if no <em>controls</em> attribute is present. They only do this if a &lt;track&gt; element has a <em>default</em> attribute. For additional details see <a href="https://github.com/ableplayer/ableplayer/issues/5">Able Player Issue 5</a>.</p>
-
+<p> Update: 11/27/2015: The bug was resolved by modifying the html sourcecode of this test page rather than the javascript itself - the "default" attribute should be avoided when embedding the player in web sites. See <a href="http://stackoverflow.com/questions/13751278/videojs-subtitle-caption-track-showing-twice-in-chrome"> this resource.</a></p>
 <p>For additional tests see the <a href="index.html">Index of <em>Able Player</em> Examples</a>.</p>
 
 <!-- use the following markup for each media element -->
 <video id="video1" preload="auto" width="480" height="360" poster="../media/wwa.jpg" data-able-player>
   <source type="video/webm" src="../media/wwa.webm"/>
 	<source type="video/mp4" src="../media/wwa.mp4"/>
-  <track kind="subtitles" src="../media/wwa_captions_es.vtt" srclang="es" label="Espanol" default/>
+  <track kind="subtitles" src="../media/wwa_captions_es.vtt" srclang="es" label="Espanol" hidden/>
+    <!-- this bug is resolved by avoiding using the "default" attribute replaced here with the attribute "hidden" -->
 	<track kind="captions" src="../media/wwa_captions_en.vtt" srclang="en" label="English"/>
 </video>
 

--- a/thirdparty/js.cookie.js
+++ b/thirdparty/js.cookie.js
@@ -1,0 +1,145 @@
+/*!
+ * JavaScript Cookie v2.0.4
+ * https://github.com/js-cookie/js-cookie
+ *
+ * Copyright 2006, 2015 Klaus Hartl & Fagner Brack
+ * Released under the MIT license
+ */
+(function (factory) {
+    if (typeof define === 'function' && define.amd) {
+        define(factory);
+    } else if (typeof exports === 'object') {
+        module.exports = factory();
+    } else {
+        var _OldCookies = window.Cookies;
+        var api = window.Cookies = factory();
+        api.noConflict = function () {
+            window.Cookies = _OldCookies;
+            return api;
+        };
+    }
+}(function () {
+    function extend () {
+        var i = 0;
+        var result = {};
+        for (; i < arguments.length; i++) {
+            var attributes = arguments[ i ];
+            for (var key in attributes) {
+                result[key] = attributes[key];
+            }
+        }
+        return result;
+    }
+
+    function init (converter) {
+        function api (key, value, attributes) {
+            var result;
+
+            // Write
+
+            if (arguments.length > 1) {
+                attributes = extend({
+                    path: '/'
+                }, api.defaults, attributes);
+
+                if (typeof attributes.expires === 'number') {
+                    var expires = new Date();
+                    expires.setMilliseconds(expires.getMilliseconds() + attributes.expires * 864e+5);
+                    attributes.expires = expires;
+                }
+
+                try {
+                    result = JSON.stringify(value);
+                    if (/^[\{\[]/.test(result)) {
+                        value = result;
+                    }
+                } catch (e) {}
+
+                if (!converter.write) {
+                    value = encodeURIComponent(String(value))
+                        .replace(/%(23|24|26|2B|3A|3C|3E|3D|2F|3F|40|5B|5D|5E|60|7B|7D|7C)/g, decodeURIComponent);
+                } else {
+                    value = converter.write(value, key);
+                }
+
+                key = encodeURIComponent(String(key));
+                key = key.replace(/%(23|24|26|2B|5E|60|7C)/g, decodeURIComponent);
+                key = key.replace(/[\(\)]/g, escape);
+
+                return (document.cookie = [
+                    key, '=', value,
+                    attributes.expires && '; expires=' + attributes.expires.toUTCString(), // use expires attribute, max-age is not supported by IE
+                    attributes.path    && '; path=' + attributes.path,
+                    attributes.domain  && '; domain=' + attributes.domain,
+                    attributes.secure ? '; secure' : ''
+                ].join(''));
+            }
+
+            // Read
+
+            if (!key) {
+                result = {};
+            }
+
+            // To prevent the for loop in the first place assign an empty array
+            // in case there are no cookies at all. Also prevents odd result when
+            // calling "get()"
+            var cookies = document.cookie ? document.cookie.split('; ') : [];
+            var rdecode = /(%[0-9A-Z]{2})+/g;
+            var i = 0;
+
+            for (; i < cookies.length; i++) {
+                var parts = cookies[i].split('=');
+                var name = parts[0].replace(rdecode, decodeURIComponent);
+                var cookie = parts.slice(1).join('=');
+
+                if (cookie.charAt(0) === '"') {
+                    cookie = cookie.slice(1, -1);
+                }
+
+                try {
+                    cookie = converter.read ?
+                        converter.read(cookie, name) : converter(cookie, name) ||
+                    cookie.replace(rdecode, decodeURIComponent);
+
+                    if (this.json) {
+                        try {
+                            cookie = JSON.parse(cookie);
+                        } catch (e) {}
+                    }
+
+                    if (key === name) {
+                        result = cookie;
+                        break;
+                    }
+
+                    if (!key) {
+                        result[name] = cookie;
+                    }
+                } catch (e) {}
+            }
+
+            return result;
+        }
+
+        api.get = api.set = api;
+        api.getJSON = function () {
+            return api.apply({
+                json: true
+            }, [].slice.call(arguments));
+        };
+        api.defaults = {};
+
+        api.remove = function (key, attributes) {
+            api(key, '', extend(attributes, {
+                expires: -1
+            }));
+        };
+
+        api.withConverter = init;
+
+        return api;
+    }
+
+    return init(function () {});
+}));


### PR DESCRIPTION
This is a workaround: using the "default" attribute is causing the behavior described in the issue, so we simply replace it with the "hidden" attribute in the source html where the player is embedded. This should be added to the documentation on what to consider when embedding the ableplayer into websites.