### PR TITLE
Regarding Issue #205

### DIFF
--- a/build/ableplayer.js
+++ b/build/ableplayer.js
@@ -3396,10 +3396,20 @@
           tracks = this.captions;
         }
         else if (popup == 'chapters') {
-          if (typeof this.chaptersPopup === 'undefined') {
-            this.chaptersPopup = this.createPopup('chapters');
-          }
-          tracks = this.chapters;
+            // sets the appropriate language for chapters if there are multiple chapter tracks available.
+            thisObj.updateChaptersLanguage();
+            if (typeof this.chaptersPopup === 'undefined') {
+              this.chaptersPopup = this.createPopup('chapters');
+            }
+            if (this.selectedChapters) {
+              tracks = this.selectedChapters.cues;
+            }
+            else if (this.chapters.length >= 1) {
+              tracks = this.chapters[0].cues;
+            }
+            else {
+              tracks = [];
+            }
         }
         else if (popup == 'ytCaptions') {
           if (typeof this.captionsPopup === 'undefined') {
@@ -4693,14 +4703,13 @@
     // Replace the following line with the commented block that follows
     // Haven't done this because it will have a big effect downstream
     // on all chapter processing
-    this.chapters = cues;
+    //this.chapters = cues;
 
-    /* // new
+    // new
     this.chapters.push({
       cues: cues,
       language: trackLang
     });
-    */
 
     if (this.chaptersDivLocation) {
       this.populateChaptersDiv();
@@ -7276,6 +7285,10 @@
     else if (this.player === 'youtube') {
       this.seekBar.setBuffered(this.youTubePlayer.getVideoLoadedFraction());
     }
+    // This will adjust the text in the chapter pop-ups.
+    // This is to respond to changes in the caption language and transcript language when appropriate.
+    // See "updateChaptersLanguage" in chapters.js to see how this is handled.
+    this.setupPopups('chapters');
   };
 
   AblePlayer.prototype.getHiddenWidth = function($el) {
@@ -7593,6 +7606,7 @@
       this.prefTranscript = 1;
     }
     this.updateCookie('prefTranscript');
+    this.setupPopups('chapters');
   };
 
   AblePlayer.prototype.handleSignToggle = function () {
@@ -8578,6 +8592,37 @@
     }
   };
 
+  AblePlayer.prototype.updateChaptersLanguage = function () {
+      var thisObj = this;
+      var matchChapLang = function (languageToMatch){
+          for (var i = 0; i < thisObj.chapters.length; i++) {
+              if(languageToMatch == thisObj.chapters[i].language){
+                  thisObj.selectedChapters = thisObj.chapters[i];
+                  return true;
+              }
+          }
+          return false;
+      };
+
+      var isSelectedChaptersUpdated = false;
+      // if captions are on, use the language of the captions
+      if(this.captionsOn || this.prefCaptions){
+          isSelectedChaptersUpdated = matchChapLang(this.captionLang);
+      }
+      // if captions are off, and the transcript is on, use the transcript language
+      if(this.prefTranscript && !(isSelectedChaptersUpdated)){
+          isSelectedChaptersUpdated = matchChapLang(this.$transcriptLanguageSelect.val());
+      }
+      // if none of the above, use the language of the player
+      if(!(isSelectedChaptersUpdated)){
+          isSelectedChaptersUpdated = matchChapLang(this.lang);
+      }
+      // if can't match any of that, use the first track in the Chapters array
+      if(!(isSelectedChaptersUpdated) && (this.chapters.length >= 1)) {
+          this.selectedChapters = (this.chapters[0]);
+      }
+  };
+
 })(jQuery);
 
 (function ($) {
@@ -8796,6 +8841,7 @@
           }
         }
         thisObj.updateTranscript();
+        thisObj.setupPopups('chapters');
       });
     }
   };
@@ -8871,7 +8917,7 @@
           }
         }
         if (typeof chapters === 'undefined') {
-          chapters = this.chapters;
+          chapters = this.chapters[0] || [];
         }
       }
 

--- a/demos/local_es.html
+++ b/demos/local_es.html
@@ -31,7 +31,8 @@
   <track kind="captions" src="../media/wwa_captions_es.vtt" srclang="es" label="Espanol" default/>
   <track kind="descriptions" src="../media/wwa_description_en.vtt" srclang="en"/>
   <track kind="descriptions" src="../media/wwa_description_es.vtt" srclang="es"/>
-  <track kind="chapters" src="../media/wwa_chapters_en.vtt"/>
+  <track kind="chapters" src="../media/wwa_chapters_en.vtt" srclang="en"/>
+  <track kind="chapters" src="../media/wwa_chapters_es.vtt" srclang="es"/>
 </video>
 
 </body>

--- a/media/wwa_chapters_es.vtt
+++ b/media/wwa_chapters_es.vtt
@@ -1,0 +1,9 @@
+WEBVTT
+
+Chapter 1
+00:00:00.000 --> 00:00:37.000
+Introducción
+
+Chapter 2
+00:00:37.000 --> 00:01:00.000
+Terrill Thompson

--- a/scripts/buildplayer.js
+++ b/scripts/buildplayer.js
@@ -596,10 +596,20 @@
           tracks = this.captions;
         }
         else if (popup == 'chapters') {
-          if (typeof this.chaptersPopup === 'undefined') {
-            this.chaptersPopup = this.createPopup('chapters');
-          }
-          tracks = this.chapters;
+            // sets the appropriate language for chapters if there are multiple chapter tracks available.
+            thisObj.updateChaptersLanguage();
+            if (typeof this.chaptersPopup === 'undefined') {
+              this.chaptersPopup = this.createPopup('chapters');
+            }
+            if (this.selectedChapters) {
+              tracks = this.selectedChapters.cues;
+            }
+            else if (this.chapters.length >= 1) {
+              tracks = this.chapters[0].cues;
+            }
+            else {
+              tracks = [];
+            }
         }
         else if (popup == 'ytCaptions') {
           if (typeof this.captionsPopup === 'undefined') {

--- a/scripts/chapters.js
+++ b/scripts/chapters.js
@@ -114,4 +114,35 @@
     }
   };
 
+  AblePlayer.prototype.updateChaptersLanguage = function () {
+      var thisObj = this;
+      var matchChapLang = function (languageToMatch){
+          for (var i = 0; i < thisObj.chapters.length; i++) {
+              if(languageToMatch == thisObj.chapters[i].language){
+                  thisObj.selectedChapters = thisObj.chapters[i];
+                  return true;
+              }
+          }
+          return false;
+      };
+
+      var isSelectedChaptersUpdated = false;
+      // if captions are on, use the language of the captions
+      if(this.captionsOn || this.prefCaptions){
+          isSelectedChaptersUpdated = matchChapLang(this.captionLang);
+      }
+      // if captions are off, and the transcript is on, use the transcript language
+      if(this.prefTranscript && !(isSelectedChaptersUpdated)){
+          isSelectedChaptersUpdated = matchChapLang(this.$transcriptLanguageSelect.val());
+      }
+      // if none of the above, use the language of the player
+      if(!(isSelectedChaptersUpdated)){
+          isSelectedChaptersUpdated = matchChapLang(this.lang);
+      }
+      // if can't match any of that, use the first track in the Chapters array
+      if(!(isSelectedChaptersUpdated) && (this.chapters.length >= 1)) {
+          this.selectedChapters = (this.chapters[0]);
+      }
+  };
+
 })(jQuery);

--- a/scripts/control.js
+++ b/scripts/control.js
@@ -599,6 +599,10 @@
     else if (this.player === 'youtube') {
       this.seekBar.setBuffered(this.youTubePlayer.getVideoLoadedFraction());
     }
+    // This will adjust the text in the chapter pop-ups.
+    // This is to respond to changes in the caption language and transcript language when appropriate.
+    // See "updateChaptersLanguage" in chapters.js to see how this is handled.
+    this.setupPopups('chapters');
   };
 
   AblePlayer.prototype.getHiddenWidth = function($el) {
@@ -916,6 +920,7 @@
       this.prefTranscript = 1;
     }
     this.updateCookie('prefTranscript');
+    this.setupPopups('chapters');
   };
 
   AblePlayer.prototype.handleSignToggle = function () {

--- a/scripts/track.js
+++ b/scripts/track.js
@@ -220,14 +220,13 @@
     // Replace the following line with the commented block that follows
     // Haven't done this because it will have a big effect downstream
     // on all chapter processing
-    this.chapters = cues;
+    //this.chapters = cues;
 
-    /* // new
+    // new
     this.chapters.push({
       cues: cues,
       language: trackLang
     });
-    */
 
     if (this.chaptersDivLocation) {
       this.populateChaptersDiv();

--- a/scripts/transcript.js
+++ b/scripts/transcript.js
@@ -104,6 +104,7 @@
           }
         }
         thisObj.updateTranscript();
+        thisObj.setupPopups('chapters');
       });
     }
   };
@@ -179,7 +180,7 @@
           }
         }
         if (typeof chapters === 'undefined') {
-          chapters = this.chapters;
+          chapters = this.chapters[0] || [];
         }
       }
 


### PR DESCRIPTION
Regarding: https://github.com/ableplayer/ableplayer/issues/205

Hey @terrill ,

I redid everything on a fresh pull because I still have two left feet when it comes to git and I couldn't get rid of all the cached files that I didn't want committed.

Anyway, to reiterate, this is my work on supporting chapters in multiple languages. There seemed to be many ways to implement this, so I decided to have the the language of the chapters match the language of the captions, then the transcript, and then the player itself, depending on the on/off state of the captions and transcripts. The details are described below, as well as in the comments of the commit.

I imagined you'd probably have a different idea for the implementation, but I thought the best start would be to put together something functioning, and then adjust as needed after getting feedback form you. For that reason, I didn't handle anything regarding "populateChaptersDiv".

Likewise, I see that the transcript title (and maybe some other things I'm unaware of) could use some similar dynamic handling; again, I was going to wait for feedback.


Some notes on testing: 

I added an extra chapters file to "local_es.html", and that's the only example where this feature can be tested. 

If the captions are on, and in Spanish, the first chapter should read "Introducción". If you change the captions to English, the first chapter changes to "Intro". 

Turn the captions off, and the chapters will go back to Spanish, as this is the language of the player.

Turn the transcripts on, and the chapters should still be in Spanish, because the transcript's default language will be Spanish.

Change the transcript's language to English (with the captions still off), the chapters should go to English as well. I found that with the new draggable transcript field I could not change the value of the transcript language with my mouse -- the only way I was able to do this was to tab to the field and use the up and down arrow keys.

From there you can test all the possible combinations of captions and transcript languages and on/off states to see if it follows the desired pattern described in more detail below. The pattern can obviously be changed as desired.

And that's all I have to say. If have the time to look at this, please let me know what you think. I'd be happy to continue working on this.

Thanks,

Jesse

-------------------------------------------------------

From the commit:

I used "local_es.html" for my testing.

I added a second chapter track file called "wwa_chapters_es.vtt" and included the source in video element in "local_es.html". Also, both chapter tracks now have a specified "scrlang". The only difference between the English chapters and the Spanish ones is that "Intro" becomes "Introducción" in Spanish. This is not to say that "Intro" would be an invalid abbreviation in Spanish, I just needed to make some distinction.

The chapter tracks are handled as follows:

1. If the captions are on, the chapter track tries to match the language of the captions.
2. If the captions are off, but the transcript is on, the chapter track tries to match the transcript.
3. If both the captions and the transcript are off (not showing), then the chapter track tries to match the player.
4. If no matches are made in any of the above situations, it defaults to the first chapter track available.

The code implementing that logic can be found in the "updateChaptersLanguage" function. (see chapters.js)

The rest of the code:

1. I created  "updateChaptersLanguage" to implement the logic as I described above. (see chapters.js)

2. In "setupPopups" I added "updateChaptersLanguage" under the condition 'else if (popup == 'chapters') '.That way it always tries to match the appropriate language before changing the text in the chapter pop-ups. (see buildplayer.js)

3. Because that is all is inside "setupPopups" it will be called by "recreatePlayer" when the player initially builds. (see ableplayer-base.js)

4. I added "setupPopups('chapters')" into "refreshControls". This makes the chapter track respond to the captions because "refreshControls()" is called in both "getCaptionClickFunction" and "getCaptionOffFunction". (see control.js)

5. To respond to changes in the language of the transcript, I added "thisObj.setupPopups ('chapters');" to the callback in "$transcriptLanguageSelect.change()". (see transcript.js)

6. To respond to the trascripts being toggled on and off, I added "this.setupPopups('chapters');" to the bottom of "handleTranscriptToggle". (see control.js)