### PR TITLE
Add separate lang tags to transcript container div and transcript heading tag

### DIFF
--- a/build/ableplayer.js
+++ b/build/ableplayer.js
@@ -9203,6 +9203,9 @@
     var $main = $('<div class="able-transcript-container"></div>');
     var transcriptTitle;
 
+    // set language for transcript container
+    $main.attr('lang', this.transcriptLang);
+
     if (typeof this.transcriptTitle !== 'undefined') {
       transcriptTitle = this.transcriptTitle;
     }
@@ -9236,6 +9239,10 @@
         });
       }
       $transcriptHeadingTag.text(transcriptTitle);
+
+      // set language of transcript heading to language of player
+      // this is independent of language of transcript
+      $transcriptHeadingTag.attr('lang', this.lang);
 
       $main.append($transcriptHeadingTag);
     }

--- a/scripts/transcript.js
+++ b/scripts/transcript.js
@@ -259,6 +259,9 @@
     var $main = $('<div class="able-transcript-container"></div>');
     var transcriptTitle;
 
+    // set language for transcript container
+    $main.attr('lang', this.transcriptLang);
+
     if (typeof this.transcriptTitle !== 'undefined') {
       transcriptTitle = this.transcriptTitle;
     }
@@ -292,6 +295,10 @@
         });
       }
       $transcriptHeadingTag.text(transcriptTitle);
+
+      // set language of transcript heading to language of player
+      // this is independent of language of transcript
+      $transcriptHeadingTag.attr('lang', this.lang);
 
       $main.append($transcriptHeadingTag);
     }


### PR DESCRIPTION
@terrill 

I just noticed that the transcript container was not getting its own lang tag to match the contents of the transcript. Also, because the transcript header is always linked to the language of the player (and doesn't match changes in the transcript language), I figured that it should receive its own lang tag as well.

This adds two lines of code in "transcript.js" to set the appropriate lang tag for each.