### PR TITLE
Hidden description span now receives value from tt dictionary

### DIFF
--- a/build/ableplayer.js
+++ b/build/ableplayer.js
@@ -9306,7 +9306,8 @@
       var $descHiddenSpan = $('<span>',{
         'class': 'able-hidden'
       });
-      $descHiddenSpan.text('Description: ');
+      $descHiddenSpan.attr('lang', thisObj.lang);
+      $descHiddenSpan.text(thisObj.tt.prefHeadingDescription + ': ');
       $descDiv.append($descHiddenSpan);
 
       var flattenComponentForDescription = function(comp) {

--- a/scripts/transcript.js
+++ b/scripts/transcript.js
@@ -363,7 +363,8 @@
       var $descHiddenSpan = $('<span>',{
         'class': 'able-hidden'
       });
-      $descHiddenSpan.text('Description: ');
+      $descHiddenSpan.attr('lang', thisObj.lang);
+      $descHiddenSpan.text(thisObj.tt.prefHeadingDescription + ': ');
       $descDiv.append($descHiddenSpan);
 
       var flattenComponentForDescription = function(comp) {


### PR DESCRIPTION
@terrill 

I don't know if this PR is necessary (you might have already made similar changes in your own repo), but here it is just in case. It is the same stuff from before now re-using the prefHeadingDescription values.

From the commit:

Previously the hidden description span had the English word "Description" hard coded into it without referencing the translated text dictionary.

Additionally, the span requires a lang tag as it will be independent of the
language of the transcript.

(See $descHiddenSpan in transcript.js)