### PR TITLE
Upgrade to jQuery 2.2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ to all use cases, both audio and video.
 ```HTML
 <!-- Dependencies -->
 <script src="thirdparty/modernizr.custom.js"></script>
-<script src="//ajax.googleapis.com/ajax/libs/jquery/1.8.2/jquery.min.js"></script>
+<script src="//ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
 <script src="thirdparty/js.cookie.js"></script>
  
 <!-- CSS --> 

--- a/demos/audio1.html
+++ b/demos/audio1.html
@@ -7,7 +7,7 @@
 
 <!-- Dependencies -->
 <script src="../thirdparty/modernizr.custom.js"></script>
-<script src="//ajax.googleapis.com/ajax/libs/jquery/1.8.2/jquery.min.js"></script>
+<script src="//ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
 <script src="../thirdparty/js.cookie.js"></script>
 
 <!-- Able Player CSS -->

--- a/demos/audio2.html
+++ b/demos/audio2.html
@@ -7,7 +7,7 @@
 
 <!-- Dependencies -->
 <script src="../thirdparty/modernizr.custom.js"></script>
-<script src="//ajax.googleapis.com/ajax/libs/jquery/1.8.2/jquery.min.js"></script>
+<script src="//ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
 <script src="../thirdparty/js.cookie.js"></script>
 
 <!-- Able Player CSS -->

--- a/demos/audio3.html
+++ b/demos/audio3.html
@@ -7,7 +7,7 @@
 
 <!-- Dependencies -->
 <script src="../thirdparty/modernizr.custom.js"></script>
-<script src="//ajax.googleapis.com/ajax/libs/jquery/1.8.2/jquery.min.js"></script>
+<script src="//ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
 <script src="../thirdparty/js.cookie.js"></script>
 
 <!-- Able Player CSS -->

--- a/demos/audio4.html
+++ b/demos/audio4.html
@@ -7,7 +7,7 @@
 
 <!-- Dependencies -->
 <script src="../thirdparty/modernizr.custom.js"></script>
-<script src="//ajax.googleapis.com/ajax/libs/jquery/1.8.2/jquery.min.js"></script>
+<script src="//ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
 <script src="../thirdparty/js.cookie.js"></script>
 
 <!-- Able Player CSS -->

--- a/demos/audio5.html
+++ b/demos/audio5.html
@@ -7,7 +7,7 @@
 
 <!-- Dependencies -->
 <script src="../thirdparty/modernizr.custom.js"></script>
-<script src="//ajax.googleapis.com/ajax/libs/jquery/1.8.2/jquery.min.js"></script>
+<script src="//ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
 <script src="../thirdparty/js.cookie.js"></script>
 
 <!-- Able Player CSS -->

--- a/demos/audio6.html
+++ b/demos/audio6.html
@@ -7,7 +7,7 @@
 
 <!-- Dependencies -->
 <script src="../thirdparty/modernizr.custom.js"></script>
-<script src="//ajax.googleapis.com/ajax/libs/jquery/1.8.2/jquery.min.js"></script>
+<script src="//ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
 <script src="../thirdparty/js.cookie.js"></script>
 
 <!-- Able Player CSS -->

--- a/demos/audio7.html
+++ b/demos/audio7.html
@@ -7,7 +7,7 @@
 
 <!-- Dependencies -->
 <script src="../thirdparty/modernizr.custom.js"></script>
-<script src="//ajax.googleapis.com/ajax/libs/jquery/1.8.2/jquery.min.js"></script>
+<script src="//ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
 <script src="../thirdparty/js.cookie.js"></script>
 
 <!-- Able Player CSS -->

--- a/demos/audio8.html
+++ b/demos/audio8.html
@@ -7,7 +7,7 @@
 
 <!-- Dependencies -->
 <script src="../thirdparty/modernizr.custom.js"></script>
-<script src="//ajax.googleapis.com/ajax/libs/jquery/1.8.2/jquery.min.js"></script>
+<script src="//ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
 <script src="../thirdparty/js.cookie.js"></script>
 
 <!-- Able Player CSS -->

--- a/demos/fallback.html
+++ b/demos/fallback.html
@@ -7,7 +7,7 @@
 
 <!-- Dependencies -->
 <script src="../thirdparty/modernizr.custom.js"></script>
-<script src="//ajax.googleapis.com/ajax/libs/jquery/1.8.2/jquery.min.js"></script>
+<script src="//ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
 <script src="../thirdparty/js.cookie.js"></script>
 
 <!-- Able Player CSS -->

--- a/demos/local_de.html
+++ b/demos/local_de.html
@@ -7,7 +7,7 @@
 
 <!-- Dependencies -->
 <script src="../thirdparty/modernizr.custom.js"></script>
-<script src="//ajax.googleapis.com/ajax/libs/jquery/1.8.2/jquery.min.js"></script>
+<script src="//ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
 <script src="../thirdparty/js.cookie.js"></script>
 
 <!-- Able Player CSS -->

--- a/demos/local_es.html
+++ b/demos/local_es.html
@@ -7,7 +7,7 @@
 
 <!-- Dependencies -->
 <script src="../thirdparty/modernizr.custom.js"></script>
-<script src="//ajax.googleapis.com/ajax/libs/jquery/1.8.2/jquery.min.js"></script>
+<script src="//ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
 <script src="../thirdparty/js.cookie.js"></script>
 
 <!-- Able Player CSS -->

--- a/demos/local_fr.html
+++ b/demos/local_fr.html
@@ -7,7 +7,7 @@
 
 <!-- Dependencies -->
 <script src="../thirdparty/modernizr.custom.js"></script>
-<script src="//ajax.googleapis.com/ajax/libs/jquery/1.8.2/jquery.min.js"></script>
+<script src="//ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
 <script src="../thirdparty/js.cookie.js"></script>
 
 <!-- Able Player CSS -->

--- a/demos/local_ja.html
+++ b/demos/local_ja.html
@@ -7,7 +7,7 @@
 
 <!-- Dependencies -->
 <script src="../thirdparty/modernizr.custom.js"></script>
-<script src="//ajax.googleapis.com/ajax/libs/jquery/1.8.2/jquery.min.js"></script>
+<script src="//ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
 <script src="../thirdparty/js.cookie.js"></script>
 
 <!-- Able Player CSS -->

--- a/demos/other1.html
+++ b/demos/other1.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <title>Native HTML5 Media Player</title>
-<script src="//ajax.googleapis.com/ajax/libs/jquery/1.8.2/jquery.min.js"></script>
+<script src="//ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
 <link rel="stylesheet" href="demos.css" type="text/css">
 <style>
 :focus {

--- a/demos/other2.html
+++ b/demos/other2.html
@@ -7,7 +7,7 @@
 
 <!-- Dependencies -->
 <script src="../thirdparty/modernizr.custom.js"></script>
-<script src="//ajax.googleapis.com/ajax/libs/jquery/1.8.2/jquery.min.js"></script>
+<script src="//ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
 <script src="../thirdparty/js.cookie.js"></script>
 
 <!-- Able Player CSS -->

--- a/demos/video1.html
+++ b/demos/video1.html
@@ -7,7 +7,7 @@
 
 <!-- Dependencies -->
 <script src="../thirdparty/modernizr.custom.js"></script>
-<script src="//ajax.googleapis.com/ajax/libs/jquery/1.8.2/jquery.min.js"></script>
+<script src="//ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
 <script src="../thirdparty/js.cookie.js"></script>
 
 <!-- Able Player CSS -->

--- a/demos/video10.html
+++ b/demos/video10.html
@@ -7,7 +7,7 @@
 
 <!-- Dependencies -->
 <script src="../thirdparty/modernizr.custom.js"></script>
-<script src="//ajax.googleapis.com/ajax/libs/jquery/1.8.2/jquery.min.js"></script>
+<script src="//ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
 <script src="../thirdparty/js.cookie.js"></script>
 
 <!-- Able Player CSS -->

--- a/demos/video11.html
+++ b/demos/video11.html
@@ -7,7 +7,7 @@
 
 <!-- Dependencies -->
 <script src="../thirdparty/modernizr.custom.js"></script>
-<script src="//ajax.googleapis.com/ajax/libs/jquery/1.8.2/jquery.min.js"></script>
+<script src="//ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
 <script src="../thirdparty/js.cookie.js"></script>
 
 <!-- Able Player CSS -->

--- a/demos/video12.html
+++ b/demos/video12.html
@@ -7,7 +7,7 @@
 
 <!-- Dependencies -->
 <script src="../thirdparty/modernizr.custom.js"></script>
-<script src="//ajax.googleapis.com/ajax/libs/jquery/1.8.2/jquery.min.js"></script>
+<script src="//ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
 <script src="../thirdparty/js.cookie.js"></script>
 
 <!-- Able Player CSS -->

--- a/demos/video13.html
+++ b/demos/video13.html
@@ -7,7 +7,7 @@
 
 <!-- Dependencies -->
 <script src="../thirdparty/modernizr.custom.js"></script>
-<script src="//ajax.googleapis.com/ajax/libs/jquery/1.8.2/jquery.min.js"></script>
+<script src="//ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
 <script src="../thirdparty/js.cookie.js"></script>
 
 <!-- Able Player CSS -->

--- a/demos/video2.html
+++ b/demos/video2.html
@@ -7,7 +7,7 @@
 
 <!-- Dependencies -->
 <script src="../thirdparty/modernizr.custom.js"></script>
-<script src="//ajax.googleapis.com/ajax/libs/jquery/1.8.2/jquery.min.js"></script>
+<script src="//ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
 <script src="../thirdparty/js.cookie.js"></script>
 
 <!-- Able Player CSS -->

--- a/demos/video3.html
+++ b/demos/video3.html
@@ -7,7 +7,7 @@
 
 <!-- Dependencies -->
 <script src="../thirdparty/modernizr.custom.js"></script>
-<script src="//ajax.googleapis.com/ajax/libs/jquery/1.8.2/jquery.min.js"></script>
+<script src="//ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
 <script src="../thirdparty/js.cookie.js"></script>
 
 <!-- Able Player CSS -->

--- a/demos/video4.html
+++ b/demos/video4.html
@@ -7,7 +7,7 @@
 
 <!-- Dependencies -->
 <script src="../thirdparty/modernizr.custom.js"></script>
-<script src="//ajax.googleapis.com/ajax/libs/jquery/1.8.2/jquery.min.js"></script>
+<script src="//ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
 <script src="../thirdparty/js.cookie.js"></script>
 
 

--- a/demos/video5.html
+++ b/demos/video5.html
@@ -7,7 +7,7 @@
 
 <!-- Dependencies -->
 <script src="../thirdparty/modernizr.custom.js"></script>
-<script src="//ajax.googleapis.com/ajax/libs/jquery/1.8.2/jquery.min.js"></script>
+<script src="//ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
 <script src="../thirdparty/js.cookie.js"></script>
 
 <!-- Able Player CSS -->

--- a/demos/video6.html
+++ b/demos/video6.html
@@ -7,7 +7,7 @@
 
 <!-- Dependencies -->
 <script src="../thirdparty/modernizr.custom.js"></script>
-<script src="//ajax.googleapis.com/ajax/libs/jquery/1.8.2/jquery.min.js"></script>
+<script src="//ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
 <script src="../thirdparty/js.cookie.js"></script>
 
 <!-- Able Player CSS -->

--- a/demos/video7.html
+++ b/demos/video7.html
@@ -7,7 +7,7 @@
 
 <!-- Dependencies -->
 <script src="../thirdparty/modernizr.custom.js"></script>
-<script src="//ajax.googleapis.com/ajax/libs/jquery/1.8.2/jquery.min.js"></script>
+<script src="//ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
 <script src="../thirdparty/js.cookie.js"></script>
 
 <!-- Able Player CSS -->

--- a/demos/video8.html
+++ b/demos/video8.html
@@ -7,7 +7,7 @@
 
 <!-- Dependencies -->
 <script src="../thirdparty/modernizr.custom.js"></script>
-<script src="//ajax.googleapis.com/ajax/libs/jquery/1.8.2/jquery.min.js"></script>
+<script src="//ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
 <script src="../thirdparty/js.cookie.js"></script>
 
 <!-- Able Player CSS -->

--- a/demos/video8b.html
+++ b/demos/video8b.html
@@ -7,7 +7,7 @@
 
 <!-- Dependencies -->
 <script src="../thirdparty/modernizr.custom.js"></script>
-<script src="//ajax.googleapis.com/ajax/libs/jquery/1.8.2/jquery.min.js"></script>
+<script src="//ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
 <script src="../thirdparty/js.cookie.js"></script>
 
 <!-- Able Player CSS -->

--- a/demos/video9.html
+++ b/demos/video9.html
@@ -7,7 +7,7 @@
 
 <!-- Dependencies -->
 <script src="../thirdparty/modernizr.custom.js"></script>
-<script src="//ajax.googleapis.com/ajax/libs/jquery/1.8.2/jquery.min.js"></script>
+<script src="//ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
 <script src="../thirdparty/js.cookie.js"></script>
 
 <!-- Able Player CSS -->

--- a/demos/youtube.html
+++ b/demos/youtube.html
@@ -7,7 +7,7 @@
 
 <!-- Dependencies -->
 <script src="../thirdparty/modernizr.custom.js"></script>
-<script src="//ajax.googleapis.com/ajax/libs/jquery/1.8.2/jquery.min.js"></script>
+<script src="//ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
 <script src="../thirdparty/js.cookie.js"></script>
 
 <!-- Able Player CSS -->

--- a/scripts/buildplayer.js
+++ b/scripts/buildplayer.js
@@ -594,7 +594,7 @@
               'id': radioId
             });
             if (track.def) {
-              trackButton.attr('checked','checked');
+              trackButton.prop('checked',true);
               hasDefault = true;
             }
             trackLabel = $('<label>',{
@@ -643,7 +643,7 @@
             });
             trackLabel.text(this.tt.captionsOff);
             if (this.prefCaptions === 0) {
-              trackButton.attr('checked','checked');
+              trackButton.prop('checked',true);
             }
             trackButton.click(this.getCaptionOffFunction());
             trackItem.append(trackButton,trackLabel);
@@ -653,11 +653,11 @@
             if ((popup == 'captions' || popup == 'ytCaptions') && (trackList.find('input:radio[lang=' + this.captionLang + ']'))) {
               // check the button associated with the default caption language
               // (as determined in control.js > syncTrackLanguages())
-              trackList.find('input:radio[lang=' + this.captionLang + ']').attr('checked','checked');
+              trackList.find('input:radio[lang=' + this.captionLang + ']').prop('checked',true);
             }
             else {
               // check the first button
-              trackList.find('input').first().attr('checked','checked');
+              trackList.find('input').first().prop('checked',true);
             }
           }
           if (popup === 'captions' || popup === 'ytCaptions') {

--- a/scripts/control.js
+++ b/scripts/control.js
@@ -587,11 +587,11 @@
       // Sync checkbox and autoScrollTranscript with user preference
       if (this.prefAutoScrollTranscript === 1) {
         this.autoScrollTranscript = true;
-        this.$autoScrollTranscriptCheckbox.attr('checked','checked');
+        this.$autoScrollTranscriptCheckbox.prop('checked',true);
       }
       else {
         this.autoScrollTranscript = false;
-        this.$autoScrollTranscriptCheckbox.removeAttr('checked');
+        this.$autoScrollTranscriptCheckbox.prop('checked',false);
       }
 
       // If transcript locked, scroll transcript to current highlight location.

--- a/scripts/initialize.js
+++ b/scripts/initialize.js
@@ -498,7 +498,7 @@
       if (typeof this.captionLang !== 'undefined') {
         // reset transcript selected <option> to this.captionLang
         if (this.$transcriptLanguageSelect) {
-          this.$transcriptLanguageSelect.find('option[lang=' + this.captionLang + ']').attr('selected','selected');
+          this.$transcriptLanguageSelect.find('option[lang=' + this.captionLang + ']').prop('selected',true);
         }
         // sync all other tracks to this same languge
         this.syncTrackLanguages('init',this.captionLang);

--- a/scripts/preference.js
+++ b/scripts/preference.js
@@ -431,7 +431,7 @@
             value: 'video'
           });
           if (this.prefDescFormat === 'video') {
-            $radio1.attr('checked','checked');
+            $radio1.prop('checked',true);
           };
           $div1.append($radio1,$label1);
 
@@ -448,7 +448,7 @@
             value: 'text'
           });
           if (this.prefDescFormat === 'text') {
-            $radio2.attr('checked','checked');
+            $radio2.prop('checked',true);
           };
           $div2.append($radio2,$label2);
         }
@@ -500,7 +500,7 @@
               text: optionText
             });
             if (this[thisPref] === optionValue) {
-              $thisOption.attr('selected','selected');
+              $thisOption.prop('selected',true);
             }
             $thisField.append($thisOption);
           }
@@ -516,7 +516,7 @@
           });
           // check current active value for this preference
           if (this[thisPref] === 1) {
-            $thisField.attr('checked','checked');
+            $thisField.prop('checked',true);
           }
           if (form === 'keyboard') {
             // add a change handler that updates the list of current keyboard shortcuts

--- a/scripts/track.js
+++ b/scripts/track.js
@@ -133,7 +133,7 @@
       });
       if (this.transcriptType === 'external' || this.transcriptType === 'popup') {
         if (isDefaultTrack) {
-          option.attr('selected', 'selected');
+          option.prop('selected', true);
         }
         this.$transcriptLanguageSelect.append(option);
       }
@@ -153,7 +153,7 @@
           });
           if (this.transcriptType === 'external' || this.transcriptType === 'popup') {
             if (isDefaultTrack) {
-              option.attr('selected', 'selected');
+              option.prop('selected', true);
             }
             option.insertBefore(options.eq(i));
           }
@@ -172,7 +172,7 @@
         });
         if (this.transcriptType === 'external' || this.transcriptType === 'popup') {
           if (isDefaultTrack) {
-            option.attr('selected', 'selected');
+            option.prop('selected', true);
           }
           this.$transcriptLanguageSelect.append(option);
         }

--- a/scripts/transcript.js
+++ b/scripts/transcript.js
@@ -195,8 +195,8 @@
       this.$transcriptDiv.html(div);
       // reset transcript selected <option> to this.transcriptLang
       if (this.$transcriptLanguageSelect) {
-        this.$transcriptLanguageSelect.find('option:selected').attr('selected','');
-        this.$transcriptLanguageSelect.find('option[lang=' + this.transcriptLang + ']').attr('selected','selected');
+        this.$transcriptLanguageSelect.find('option:selected').prop('selected',false);
+        this.$transcriptLanguageSelect.find('option[lang=' + this.transcriptLang + ']').prop('selected',true);
       }
     }
 


### PR DESCRIPTION
Upgrade jQuery from 1.8.2 to 2.2.4.  This is currently the latest 2.x release; I've seen a few mentions in other Able Player GitHub issues of people having trouble going straight to 3.x, so this seems like a good intermediate step.  The jQuery Migrate plugin only reported some misuse of `.attr()` vs. `prop()` that could cause problems in 1.9 and above, so I fixed all of those I could find.  Otherwise, after these changes it seems to be working ok even without the migrate plugin.