### PR TITLE
Issue #318 - Play button not responding to keypress in Chrome/JAWS

### DIFF
--- a/scripts/buildplayer.js
+++ b/scripts/buildplayer.js
@@ -945,7 +945,8 @@
       controls = controlLayout[sectionByOrder[i]];
       if ((i % 2) === 0) {
         $controllerSpan = $('<div>',{
-          'class': 'able-left-controls'
+          'class': 'able-left-controls',
+          'role': 'application' // See https://github.com/ableplayer/ableplayer/issues/318
         });
       }
       else {
@@ -1027,7 +1028,8 @@
             'type': 'button',
             'tabindex': '0',
             'aria-label': buttonTitle,
-            'class': 'able-button-handler-' + control
+            'class': 'able-button-handler-' + control,
+            'role': 'application'  // See https://github.com/ableplayer/ableplayer/issues/318
           });
           if (control === 'volume' || control === 'preferences') {
             // This same ARIA for captions and chapters are added elsewhere


### PR DESCRIPTION
This is my attempt at a fix for the following issue (#318):

When running JAWS in combination with Chrome, the video player's "play"
button was not responding to enter/spacebar.

*Steps to Reproduce* (before this fix is applied):

* In Chrome, Navigate to: https://ableplayer.github.io/ableplayer/demos/video1.html
  * Make sure JAWS is running
  * Pick any of the `Video Examples`
  * Tab around the page until you get to the Play button
  * Press enter or spacebar and notice you only hear a "bleep-bloop" and nothing happens
  * Quit the JAWS application and tab to the Play button. It now works as expected.

*Work-around* (before this fix is applied):

* Launch JAWS
* Tab to the play button
* Press enter, you will hear "Group box"
* Press Tab, notice the re-play button is highlighted
* Press left-arrow, announcement will be "p"
* Press Enter, the video will play
* Press Tab, notice the re-play button is highlighted
* Press left-arrow, announcement will be "a"
* Press Enter, the video will play

After this fix is applied:

Both enter/spacebar work in Chrome, IE11, Firefox withe JAWS

*Warning*: I don't know how other screenreaders will react to this
change, they too should be tested