### PR TITLE
#414 Handle missing or unloadable subtitle track

### DIFF
--- a/scripts/track.js
+++ b/scripts/track.js
@@ -67,7 +67,7 @@
 				var trackSrc = track.src;
 
 				loadingPromise = thisObj.loadTextObject(trackSrc); // resolves with src, trackText
-				loadingPromises.push(loadingPromise);
+				loadingPromises.push(loadingPromise.catch(function(src) { console.warn('Failed to load captions track from ' + src); }));
 
 				loadingPromise.then((function (track, kind) {
 
@@ -369,7 +369,7 @@ if (thisObj.useTtml && (trackSrc.endsWith('.xml') || trackText.startsWith('<?xml
 				if (thisObj.debug) {
 					console.log ('error reading file ' + src + ': ' + status);
 				}
-				deferred.fail();
+				deferred.reject(src);
 			}
 			else {
 				deferred.resolve(src, trackText);


### PR DESCRIPTION
Allow video player construction to continue if one or more subtitle tracks don't load properly

- Deferred.fail just registers handlers, so that deferred was never being completed and processing would stall
- Deferred.reject (which is correct here) causes the overall deferred wrapping loadingPromises to fail, adding .catch means that the other tracks are loaded normally and player construction can continue
- Could extend to register an error handler rather than just calling console.warn (which gets removed from dist/min versions) but we didn't need that