### PR TITLE
Fix outer clicks for safari

### DIFF
--- a/scripts/event.js
+++ b/scripts/event.js
@@ -836,7 +836,7 @@
 		});
 
 		// handle clicks (left only) anywhere on the page. If any popups are open, close them.
-		$(document).on('click',function(e) {
+		$('body').on('click',function(e) {
 
 			if (e.button !== 0) { // not a left click
 				return false;


### PR DESCRIPTION
Ableplayer uses `$(document).on('click' ...` to detect clicks anywhere on the page to close popups. This works in Chrome and Firefox. But it doesn't work on Safari on macOS. So on Safari on desktop the popups remain open when clicked outside.

Replacing this with `$('body').on('click' ...` makes it work everywhere including Safari.