### PR TITLE
fix(initSpeech): namespace and single-shot click handler to preserve …

### DIFF
--- a/build/ableplayer.js
+++ b/build/ableplayer.js
@@ -7723,14 +7723,14 @@ var AblePlayerInstances = [];
 					// handle a click on anything, in case the user 
 					// clicks something before they click 'play' or 'prefs' buttons
 					// that would allow us to init speech before it's needed 
-					$(document).on('click',function() { 			
+					$(document).one('click.ableInitSpeech', function () { 			
 						var greeting = new SpeechSynthesisUtterance('Hi!');
 						greeting.volume = 0; // silent 
 						greeting.rate = 10; // fastest speed supported by the API  
 						thisObj.synth.speak(greeting);
 						greeting.onstart = function(e) { 						
 							// utterance has started 
-							$(document).off('click'); // unbind the click event listener 		
+							$(document).off('click.ableInitSpeech'); // unbind the click event listener 		
 						}
 						greeting.onend = function(e) {
 							// should now be able to get browser voices 
@@ -7756,7 +7756,7 @@ var AblePlayerInstances = [];
 					thisObj.synth.speak(greeting);
 					greeting.onstart = function(e) { 						
 						// utterance has started 
-						$(document).off('click'); // unbind the click event listener 			
+						$(document).off('click.ableInitSpeech'); // unbind the click event listener 			
 					};
 					greeting.onend = function(e) {
 						// should now be able to get browser voices 


### PR DESCRIPTION
…external UI events

The previous implementation used a global, persistent click listener, which in some environments (notably page builders like Elementor) interfered with other UI components such as popups or dropdowns.

Using .one() ensures the listener is automatically removed after the first click, reducing overhead and risk of side effects.

Adding an event namespace (.ableInitSpeech) makes the listener easier to manage and avoids conflicts with other click handlers.