### PR TITLE
VTT parsing - Allow hour section that isn't 2 digits

### DIFF
--- a/scripts/webvtt.js
+++ b/scripts/webvtt.js
@@ -727,7 +727,9 @@
 		}
 		var timestamp = cut(state, nextSpace);
 
-		var results = /((\d\d):)?((\d\d):)(\d\d).(\d\d\d)|(\d+).(\d\d\d)/.exec(timestamp);
+		// The spec requires exactly 2 characters for minutes and seconds, and 2+ for hours,
+		// but some VTT generation creates 1 digit hour times (e.g. "1:02:24.000 --> 1:04:48.000") and it seems harmless to allow that here
+		var results = /((\d+):)?((\d\d):)(\d\d).(\d\d\d)|(\d+).(\d\d\d)/.exec(timestamp);
 
 		if (!results) {
 			state.error = 'Unable to parse timestamp';


### PR DESCRIPTION
- Allow more than 2 digits for extremely long videos
- Although the spec says it must be 2+ and so single digit times (e.g. 1:02:24.000 --> 1:04:48.000) are invalid, allow these too as it's unambiguous what was intended and easy to handle

Timestamps like this are the cause of a real customer supported issue for us, so while it would be fair to tell them to fix their VTT generation, it would be good to be able to parse and allow them.