### PR TITLE
fix for regex in the postprocessCTag function

### DIFF
--- a/scripts/validate.js
+++ b/scripts/validate.js
@@ -106,7 +106,7 @@ var postProcessing = {
     return vttContent.replace(
       /<c class="([\w\s]+)">/g,
       function (_, classNames) {
-        var classes = classNames.replace(/\./g, " ");
+        var classes = classNames.replace(/ /g, ".");
         return "<c." + classes + ">";
       }
     );


### PR DESCRIPTION
## Description
The regex for post-processing in the postprocessCTag in the validate.js file was removing a dot and leaving a space rather than the other way around. 

## How Has This Been Tested?
Ran jest tests via `npm run test`

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ x ] My code is tested.
- [ x ] My code has proper inline documentation.
