### PR TITLE
#692 Parse timestamp tags in WebVTT

### DIFF
--- a/scripts/validate.js
+++ b/scripts/validate.js
@@ -185,8 +185,9 @@ var validate = {
     var processedLangTags = postProcessing.postprocessLangTag(processedVTags);
 
     var arrowReplaced = processedLangTags.replace(/--&gt;/g, "-->");
+    var timestampTagReplaced = arrowReplaced.replace(/&lt;([\d:.]+)&gt;/g, '<$1>');
 
-    var finalContent = arrowReplaced.replace(
+    var finalContent = timestampTagReplaced.replace(
       /<\/v>/g,
       function (match, offset) {
         return originalVttContent.indexOf(match, offset) !== -1 ? match : "";


### PR DESCRIPTION
These get sanitized by DOMPurify, we need to put them back.

Verified with the WebVTT linked in the issue