### PR TITLE
Remove dialog elements on dispose()

### DIFF
--- a/scripts/ableplayer-base.js
+++ b/scripts/ableplayer-base.js
@@ -496,6 +496,30 @@ function ablePlayerSetupWindow() {
 	 */
 	AblePlayer.prototype.dispose = function () {
 		AblePlayer.ablePlayerInstances.delete(this);
+
+		// Look for various dialogs tied to this instance. Elements associated
+		// with these are appended to the body, and they need to be
+		// `.remove()`d here.
+		const dialogs = [
+			this.captionPrefsDialog,
+			this.descPrefsDialog,
+			this.keyboardPrefsDialog,
+			this.transcriptPrefsDialog,
+			this.transcriptResizeDialog,
+			this.signResizeDialog,
+		];
+
+		for (const dialog of dialogs) {
+			if (!dialog) {
+				continue;
+			}
+			if (dialog.modal) {
+				dialog.modal.remove();
+			}
+			if (dialog.overlay) {
+				dialog.overlay.remove();
+			}
+		}
 	}
 
 	AblePlayer.getActiveDOMElement = function () {


### PR DESCRIPTION
<!--
BEFORE OPENING YOUR PULL REQUEST:
- Make sure your Pull Request is being made against the `develop` branch of Able Player.
- Make sure your code is properly documented.
-->

## Description
<!-- Please describe your changes -->
<!-- Please provide a link to the issue this PR is intended to fix: -->

`player.dispose()` now also removes the instance's dialog elements from `<body>`.

Partial fix for https://github.com/ableplayer/ableplayer/issues/658 . There are still too many dialogs for multiple players on a page, but this at least prevents the list from growing with every add/remove cycle.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Clicked around `/demos/external6.html` and kept a close eye on the "Elements" tab in the dev console. On https://ableplayer.github.io/ableplayer/demos/external6.html you can see the modals proliferating. After this change, the extra elements disappear when the players do.

## Screenshots (jpeg or gifs if applicable):

Before:

<img width="1608" height="728" alt="image" src="https://github.com/user-attachments/assets/f8b3861d-a3f6-4f1a-afaa-b1701217173a" />

After:

<img width="1701" height="702" alt="image" src="https://github.com/user-attachments/assets/76990ff9-7e5e-4fc2-a511-d73810a03769" />


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Bug fix. It's possible someone was relying on these modals sticking around, but, seems unlikely.

## Checklist:
- [x] My code is tested.
- [x] My code has proper inline documentation.
