### PR TITLE
Fix all 7 ESLint errors reported by npm run lint

### DIFF
--- a/scripts/ableplayer-base.js
+++ b/scripts/ableplayer-base.js
@@ -132,11 +132,7 @@ class AblePlayer {
 		// set to "false" if the sole purpose of the WebVTT descriptions file
 		// is to integrate text description into the transcript
 		// set to "true" to write description text to a div
-		let descriptionAudible = options.descriptionAudible ?? data.descriptionAudible;
 		if (descriptionsAudible !== undefined && descriptionsAudible === false) {
-			this.readDescriptionsAloud = false;
-		} else if (descriptionAudible !== undefined && descriptionAudible === false) {
-			// support both singular and plural spelling of attribute
 			this.readDescriptionsAloud = false;
 		} else {
 			this.readDescriptionsAloud = true;

--- a/scripts/ableplayer-base.js
+++ b/scripts/ableplayer-base.js
@@ -132,9 +132,10 @@ class AblePlayer {
 		// set to "false" if the sole purpose of the WebVTT descriptions file
 		// is to integrate text description into the transcript
 		// set to "true" to write description text to a div
+		let descriptionAudible = options.descriptionAudible ?? data.descriptionAudible;
 		if (descriptionsAudible !== undefined && descriptionsAudible === false) {
 			this.readDescriptionsAloud = false;
-		} else if (descriptionsAudible !== undefined && descriptionsAudible === false) {
+		} else if (descriptionAudible !== undefined && descriptionAudible === false) {
 			// support both singular and plural spelling of attribute
 			this.readDescriptionsAloud = false;
 		} else {

--- a/scripts/dialog.js
+++ b/scripts/dialog.js
@@ -1,4 +1,5 @@
 import $ from 'jquery';
+import AblePlayer from './ableplayer-base';
 
 var focusableElementsSelector = "a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), iframe, object, embed, *[tabindex], *[contenteditable]";
 

--- a/scripts/dragdrop.js
+++ b/scripts/dragdrop.js
@@ -287,9 +287,8 @@ function addDragdropFunctions(AblePlayer) {
 
 	AblePlayer.prototype.handleWindowButtonClick = function (which, e) {
 
-		var thisObj, $windowPopup, $windowButton, $toolbar, popupTop;
+		var $windowPopup, $windowButton, $toolbar, popupTop;
 
-		thisObj = this;
 		if (this.focusNotClick) {
 			// transcript or sign window has just opened,
 			// and focus moved to the window button
@@ -309,6 +308,7 @@ function addDragdropFunctions(AblePlayer) {
 		if (e.type === 'keydown') {
 			// user pressed a key
 			if (e.key === ' ' || e.key === 'Enter') {
+				// Space or Enter: fall through to the toggle logic below
 			} else if (e.key === 'Escape') {
 				if ($windowPopup.is(':visible')) {
 					// close the popup menu
@@ -349,10 +349,9 @@ function addDragdropFunctions(AblePlayer) {
 
 	AblePlayer.prototype.handleMenuChoice = function (which, choice, e) {
 
-		var thisObj, $window, $windowPopup, $windowButton, resizeDialog, startingWidth, startingHeight,
+		var $window, $windowPopup, $windowButton, resizeDialog, startingWidth, startingHeight,
 			aspectRatio, tempWidth, tempHeight;
 
-		thisObj = this;
 		if (which === 'transcript') {
 			$window = this.$transcriptArea;
 			$windowPopup = this.$transcriptPopup;

--- a/scripts/preference.js
+++ b/scripts/preference.js
@@ -521,7 +521,7 @@
 		var thisObj, available,
 			$prefsDiv, formTitle, introText, $prefsIntro,$prefsIntroP2,p3Text,$prefsIntroP3,i, j,
 			$fieldset, groupHeading, groupObj, thisPref, $thisDiv, thisClass,
-			thisId, $thisLabel, $thisField, captionsOptions,options,$thisOption,optionValue,optionLang,optionText,
+			thisId, $thisField, captionsOptions,options,$thisOption,optionValue,optionLang,optionText,
 			changedPref,changedSpan,changedText, currentDescState, prefDescVoice, prefCaptionVoice, $kbHeading,$kbList,
 			kbLabels,keys,kbListText,$kbListItem, dialog,$saveButton,$cancelButton,$buttonContainer, sharedDialog;
 
@@ -639,7 +639,6 @@
 						} : undefined
 					});
 					$thisDiv = fieldObj.wrapper;
-					$thisLabel = fieldObj.label;
 					$thisField = fieldObj.field;
 					// add a change handler that updates the style of the sample caption text
 					let viewingOptions = ['prefCaptionsPosition','prefCaptionsFont','prefCaptionsSize','prefCaptionsColor','prefCaptionsBGColor','prefCaptionsOpacity'];
@@ -752,8 +751,6 @@
 							checked: this[thisPref] === 1
 						});
 						$thisDiv = fieldObj.wrapper;
-						$thisLabel = fieldObj.label;
-						$thisField = fieldObj.field;
 					} else if (this.synth) {
 						let isDescRateField = (thisPref === 'prefDescRate');
 						// Only show these options if browser supports speech synthesis
@@ -771,7 +768,6 @@
 							} : undefined
 						});
 						$thisDiv = fieldObj.wrapper;
-						$thisLabel = fieldObj.label;
 						$thisField = fieldObj.field;
 						if (isDescRateField) {
 							// Number field has no options to populate.
@@ -844,7 +840,6 @@
 						checked: this[thisPref] === 1
 					});
 					$thisDiv = fieldObj.wrapper;
-					$thisLabel = fieldObj.label;
 					$thisField = fieldObj.field;
 					if (form === 'keyboard') {
 						// add a change handler that updates the list of current keyboard shortcuts


### PR DESCRIPTION
Hi @joedolson — we run Able Player v5 in production (YouTube grids on an accessibility-first creator platform) and would like to start contributing back. Starting small with the lint baseline so later PRs stay clean.

## What

Fixes every error `npm run lint` currently reports on `develop` (7 errors, 4 files):

- **scripts/ableplayer-base.js** — the `descriptionsAudible` else-if repeats the first condition (`no-dupe-else-if`). The comment says the branch supports "both singular and plural spelling of attribute", but the singular form was never read. The branch now reads `options.descriptionAudible ?? data.descriptionAudible`, so `data-description-audible` works as the comment intends. Happy to drop this hunk and simply delete the dead branch if the singular spelling was never meant to be supported.
- **scripts/dialog.js** — adds the missing `AblePlayer` import for `AblePlayer.getActiveDOMElement()` (`no-undef`).
- **scripts/dragdrop.js** — removes two unused `thisObj` locals (`no-unused-vars`); comments the intentionally-empty Space/Enter branch (`no-empty`).
- **scripts/preference.js** — removes the write-only `$thisLabel` and one dead `$thisField` assignment (`no-unused-vars`, `no-useless-assignment`).

## Verification

- `npm run lint`: 0 problems (was 7)
- `npx jest --selectProjects jsdom`: 55/55 pass
- `npm run build`: clean; build artifacts not committed per contributing.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)