### PR TITLE
Add GitHub Actions CI and make the puppeteer suite run headless with no local server

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,10 @@
 # Continuous integration for Able Player
 #
-# Runs ESLint and the jsdom Jest project on every push and pull request.
-# The puppeteer Jest project (validate.test.cjs) needs a demo server on
-# localhost:8000 and a headed browser, so it is not run here yet — see
-# jest.config.cjs. Build artifacts are compiled to confirm Grunt + Rollup
-# succeed, but are never committed (per contributing.md).
+# Runs ESLint and both Jest projects (jsdom + puppeteer) on every push and
+# pull request. The puppeteer project runs headless with request
+# interception, so no demo server is needed. Build artifacts are compiled
+# to confirm Grunt + Rollup succeed, but are never committed (per
+# contributing.md).
 name: CI
 
 on:
@@ -39,6 +39,20 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npx jest --selectProjects jsdom
+
+  test-browser:
+    name: Jest (puppeteer, headless)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      # validate.test.cjs loads build/test/validate.umd.js
+      - run: npm run build
+      - run: npx jest --selectProjects puppeteer
 
   build:
     name: Build (Grunt + Rollup)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,17 @@ on:
 permissions:
   contents: read
 
+# Superseded runs on the same ref are cancelled, so a force-push to an open
+# pull request does not leave stale jobs occupying the queue.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: ESLint
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -31,6 +38,7 @@ jobs:
   test:
     name: Jest (jsdom)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -38,11 +46,16 @@ jobs:
           node-version: 22
           cache: npm
       - run: npm ci
+      # webvtt.test.cjs loads build/test/webvtt.umd.js, so the suite must run
+      # against a fresh build rather than the committed bundle — otherwise a
+      # change to the WebVTT source is never actually exercised.
+      - run: npm run build
       - run: npx jest --selectProjects jsdom
 
   test-browser:
     name: Jest (puppeteer, headless)
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -57,6 +70,7 @@ jobs:
   build:
     name: Build (Grunt + Rollup)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,59 @@
+# Continuous integration for Able Player
+#
+# Runs ESLint and the jsdom Jest project on every push and pull request.
+# The puppeteer Jest project (validate.test.cjs) needs a demo server on
+# localhost:8000 and a headed browser, so it is not run here yet — see
+# jest.config.cjs. Build artifacts are compiled to confirm Grunt + Rollup
+# succeed, but are never committed (per contributing.md).
+name: CI
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: ESLint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run lint
+
+  test:
+    name: Jest (jsdom)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npx jest --selectProjects jsdom
+
+  build:
+    name: Build (Grunt + Rollup)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - name: Confirm build outputs exist
+        run: |
+          test -s build/ableplayer.js
+          test -s build/ableplayer.min.js
+          test -s build/ableplayer.esm.js
+          test -s build/ableplayer.min.css

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,11 @@ jobs:
         with:
           node-version: 22
           cache: npm
+      # Only the puppeteer job launches a browser; skip puppeteer's Chromium
+      # download elsewhere (setup-node's npm cache does not cover it).
       - run: npm ci
+        env:
+          PUPPETEER_SKIP_DOWNLOAD: "1"
       - run: npm run lint
 
   test:
@@ -46,6 +50,8 @@ jobs:
           node-version: 22
           cache: npm
       - run: npm ci
+        env:
+          PUPPETEER_SKIP_DOWNLOAD: "1"
       # webvtt.test.cjs loads build/test/webvtt.umd.js, so the suite must run
       # against a fresh build rather than the committed bundle — otherwise a
       # change to the WebVTT source is never actually exercised.
@@ -78,6 +84,8 @@ jobs:
           node-version: 22
           cache: npm
       - run: npm ci
+        env:
+          PUPPETEER_SKIP_DOWNLOAD: "1"
       - run: npm run build
       - name: Confirm build outputs exist
         run: |

--- a/contributing.md
+++ b/contributing.md
@@ -78,7 +78,7 @@ Able Player uses [Jest][] to run automated tests. Tests are found in `scripts/__
 npm test
 ```
 
-Because Able Player doesn't configure its own local environment, you can run it in any local setup; but you may need to adjust the test runner's target URL for tests requiring a local URL. The default is `http://localhost:8000`.
+The suite runs headless and needs no local server: the browser-based tests intercept their own navigation. To watch the browser while debugging, run `HEADFUL=1 npm test`.
 
 Please run the test suite against your changes to ensure there are no unexpected changes.
 

--- a/jest-puppeteer.config.cjs
+++ b/jest-puppeteer.config.cjs
@@ -3,7 +3,9 @@
 // Set HEADFUL=1 to watch the browser while debugging.
 module.exports = {
   launch: {
-    headless: process.env.HEADFUL ? false : true,
+    // Compared explicitly: HEADFUL=0 is a truthy string, and it should mean
+    // "stay headless" rather than launching a visible browser.
+    headless: !["1", "true"].includes(process.env.HEADFUL),
     // Chromium's sandbox is unavailable in most CI containers.
     args: process.env.CI ? ["--no-sandbox", "--disable-setuid-sandbox"] : [],
   },

--- a/jest-puppeteer.config.cjs
+++ b/jest-puppeteer.config.cjs
@@ -1,6 +1,10 @@
 // jest-puppeteer.config.js
+// Headless by default so `npm test` runs unattended (locally and in CI).
+// Set HEADFUL=1 to watch the browser while debugging.
 module.exports = {
   launch: {
-    headless: false, // Set to true to run tests in headless mode
+    headless: process.env.HEADFUL ? false : true,
+    // Chromium's sandbox is unavailable in most CI containers.
+    args: process.env.CI ? ["--no-sandbox", "--disable-setuid-sandbox"] : [],
   },
 };

--- a/scripts/__tests__/validate.test.cjs
+++ b/scripts/__tests__/validate.test.cjs
@@ -8,7 +8,23 @@ const path = require("path");
  */
 describe("validate.js tests", () => {
   beforeAll(async () => {
-    await page.goto("http://localhost:8000"); // Replace with your test URL
+    // The suite needs a real http(s) origin (isProtocolSafe resolves
+    // relative URLs against window.location.origin, which is opaque on
+    // about:blank), but no actual server: intercept the navigation and
+    // fulfill it with an empty page.
+    await page.setRequestInterception(true);
+    page.on("request", (request) => {
+      if (request.url().startsWith("http://ableplayer.test/")) {
+        request.respond({
+          status: 200,
+          contentType: "text/html",
+          body: "<!doctype html><html><head></head><body></body></html>",
+        });
+      } else {
+        request.continue();
+      }
+    });
+    await page.goto("http://ableplayer.test/");
     const validatePath = path.resolve(__dirname, "../../build/test/validate.umd.js");
     // Add DOMPurify script
     const domPurifyPath = path.resolve(

--- a/scripts/ableplayer-base.js
+++ b/scripts/ableplayer-base.js
@@ -132,11 +132,7 @@ class AblePlayer {
 		// set to "false" if the sole purpose of the WebVTT descriptions file
 		// is to integrate text description into the transcript
 		// set to "true" to write description text to a div
-		let descriptionAudible = options.descriptionAudible ?? data.descriptionAudible;
 		if (descriptionsAudible !== undefined && descriptionsAudible === false) {
-			this.readDescriptionsAloud = false;
-		} else if (descriptionAudible !== undefined && descriptionAudible === false) {
-			// support both singular and plural spelling of attribute
 			this.readDescriptionsAloud = false;
 		} else {
 			this.readDescriptionsAloud = true;

--- a/scripts/ableplayer-base.js
+++ b/scripts/ableplayer-base.js
@@ -132,9 +132,10 @@ class AblePlayer {
 		// set to "false" if the sole purpose of the WebVTT descriptions file
 		// is to integrate text description into the transcript
 		// set to "true" to write description text to a div
+		let descriptionAudible = options.descriptionAudible ?? data.descriptionAudible;
 		if (descriptionsAudible !== undefined && descriptionsAudible === false) {
 			this.readDescriptionsAloud = false;
-		} else if (descriptionsAudible !== undefined && descriptionsAudible === false) {
+		} else if (descriptionAudible !== undefined && descriptionAudible === false) {
 			// support both singular and plural spelling of attribute
 			this.readDescriptionsAloud = false;
 		} else {

--- a/scripts/dialog.js
+++ b/scripts/dialog.js
@@ -1,4 +1,5 @@
 import $ from 'jquery';
+import AblePlayer from './ableplayer-base';
 
 var focusableElementsSelector = "a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), iframe, object, embed, *[tabindex], *[contenteditable]";
 

--- a/scripts/dragdrop.js
+++ b/scripts/dragdrop.js
@@ -287,9 +287,8 @@ function addDragdropFunctions(AblePlayer) {
 
 	AblePlayer.prototype.handleWindowButtonClick = function (which, e) {
 
-		var thisObj, $windowPopup, $windowButton, $toolbar, popupTop;
+		var $windowPopup, $windowButton, $toolbar, popupTop;
 
-		thisObj = this;
 		if (this.focusNotClick) {
 			// transcript or sign window has just opened,
 			// and focus moved to the window button
@@ -309,6 +308,7 @@ function addDragdropFunctions(AblePlayer) {
 		if (e.type === 'keydown') {
 			// user pressed a key
 			if (e.key === ' ' || e.key === 'Enter') {
+				// Space or Enter: fall through to the toggle logic below
 			} else if (e.key === 'Escape') {
 				if ($windowPopup.is(':visible')) {
 					// close the popup menu
@@ -349,10 +349,9 @@ function addDragdropFunctions(AblePlayer) {
 
 	AblePlayer.prototype.handleMenuChoice = function (which, choice, e) {
 
-		var thisObj, $window, $windowPopup, $windowButton, resizeDialog, startingWidth, startingHeight,
+		var $window, $windowPopup, $windowButton, resizeDialog, startingWidth, startingHeight,
 			aspectRatio, tempWidth, tempHeight;
 
-		thisObj = this;
 		if (which === 'transcript') {
 			$window = this.$transcriptArea;
 			$windowPopup = this.$transcriptPopup;

--- a/scripts/preference.js
+++ b/scripts/preference.js
@@ -521,7 +521,7 @@
 		var thisObj, available,
 			$prefsDiv, formTitle, introText, $prefsIntro,$prefsIntroP2,p3Text,$prefsIntroP3,i, j,
 			$fieldset, groupHeading, groupObj, thisPref, $thisDiv, thisClass,
-			thisId, $thisLabel, $thisField, captionsOptions,options,$thisOption,optionValue,optionLang,optionText,
+			thisId, $thisField, captionsOptions,options,$thisOption,optionValue,optionLang,optionText,
 			changedPref,changedSpan,changedText, currentDescState, prefDescVoice, prefCaptionVoice, $kbHeading,$kbList,
 			kbLabels,keys,kbListText,$kbListItem, dialog,$saveButton,$cancelButton,$buttonContainer, sharedDialog;
 
@@ -639,7 +639,6 @@
 						} : undefined
 					});
 					$thisDiv = fieldObj.wrapper;
-					$thisLabel = fieldObj.label;
 					$thisField = fieldObj.field;
 					// add a change handler that updates the style of the sample caption text
 					let viewingOptions = ['prefCaptionsPosition','prefCaptionsFont','prefCaptionsSize','prefCaptionsColor','prefCaptionsBGColor','prefCaptionsOpacity'];
@@ -752,8 +751,6 @@
 							checked: this[thisPref] === 1
 						});
 						$thisDiv = fieldObj.wrapper;
-						$thisLabel = fieldObj.label;
-						$thisField = fieldObj.field;
 					} else if (this.synth) {
 						let isDescRateField = (thisPref === 'prefDescRate');
 						// Only show these options if browser supports speech synthesis
@@ -771,7 +768,6 @@
 							} : undefined
 						});
 						$thisDiv = fieldObj.wrapper;
-						$thisLabel = fieldObj.label;
 						$thisField = fieldObj.field;
 						if (isDescRateField) {
 							// Number field has no options to populate.
@@ -844,7 +840,6 @@
 						checked: this[thisPref] === 1
 					});
 					$thisDiv = fieldObj.wrapper;
-					$thisLabel = fieldObj.label;
 					$thisField = fieldObj.field;
 					if (form === 'keyboard') {
 						// add a change handler that updates the list of current keyboard shortcuts


### PR DESCRIPTION
Follow-up to #770 (includes its lint commit so CI starts green — happy to rebase once that merges).

## What

Two changes that make the existing test suite protective:

**1. GitHub Actions CI** (`.github/workflows/ci.yml`) — the repo ships ESLint + Jest configs but no CI. Four jobs on every push/PR: ESLint, Jest jsdom (55 tests), Jest puppeteer headless (26 tests), and a Grunt + Rollup build with artifact existence checks (build output never committed, per contributing.md). Node 22, npm cache, `GITHUB_TOKEN` restricted to `contents: read`.

**2. Headless, serverless puppeteer suite** — `npm test` currently fails 26/81 out of the box: `validate.test.cjs` expects a manually-started server on `localhost:8000`, and `jest-puppeteer.config.cjs` sets `headless: false` (needs a display).
- `jest-puppeteer.config.cjs`: headless by default, `HEADFUL=1` to watch while debugging, `--no-sandbox` under CI.
- `validate.test.cjs`: request interception replaces the server — the page navigates to `http://ableplayer.test/` fulfilled from memory. A real http(s) origin is still needed because `isProtocolSafe()` resolves relative URLs against `window.location.origin` (opaque on `about:blank`), but no server process.

## Verification

- `npm test`: **81/81 pass** locally with zero setup (was 55/81 + manual server)
- The identical workflow is green on our fork: https://github.com/blogcastAI/ableplayer/actions

## Why

contributing.md calls test-suite expansion a high priority — CI plus a suite that runs unattended is the prerequisite that makes new tests protective rather than advisory. We run Able Player v5 in production and plan further contributions (YouTube issue cluster #736/#670/#606 next).

🤖 Generated with [Claude Code](https://claude.com/claude-code)